### PR TITLE
Update Java and Kotlin dependencies to fix build failures

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -49,8 +49,8 @@
         <!-- Project configuration -->
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-        <maven.compiler.source>1.7</maven.compiler.source>
-        <maven.compiler.target>1.7</maven.compiler.target>
+        <maven.compiler.source>8</maven.compiler.source>
+        <maven.compiler.target>8</maven.compiler.target>
 
         <!-- Maven plugins -->
         <maven-failsafe.version>2.21.0</maven-failsafe.version>
@@ -65,13 +65,13 @@
         <cassandra-driver.version>3.3.2</cassandra-driver.version>
         <cassandra-unit.version>3.3.0.2</cassandra-unit.version>
         <commons-logging.version>1.2</commons-logging.version>
-        <config4k.version>0.3.0</config4k.version> <!-- Last version to support Kotlin 1.x -->
+        <config4k.version>0.4.2</config4k.version>
         <hamcrest-junit.version>2.0.0.0</hamcrest-junit.version>
         <junit.version>4.12</junit.version>
-        <kotlin.version>1.0.7</kotlin.version>
-        <kotlin-test.version>1.3.5</kotlin-test.version> <!-- Last version to support Kotlin 1.x -->
+        <kotlin.version>1.4.0</kotlin.version>
+        <kotlin-test.version>1.3.7</kotlin-test.version>
         <mockito.version>2.7.22</mockito.version>
-        <mockito-kotlin.version>1.4.0</mockito-kotlin.version> <!-- Last version to support Kotlin 1.x -->
+        <mockito-kotlin.version>1.6.0</mockito-kotlin.version>
         <slf4j.version>1.7.25</slf4j.version>
         <system-rules.version>1.17.1</system-rules.version>
         <typesafe-config.version>1.2.1</typesafe-config.version> <!-- Last version to support Java 6 -->
@@ -79,8 +79,8 @@
 
     <repositories>
         <repository>
-            <id>jcenter</id>
-            <url>https://jcenter.bintray.com/</url>
+            <id>central</id>
+            <url>https://repo1.maven.org/maven2/</url>
         </repository>
     </repositories>
 

--- a/scripts/deploy.sh
+++ b/scripts/deploy.sh
@@ -18,4 +18,4 @@
 #   limitations under the License.
 ###
 
-./mvnw source:jar javadoc:jar deploy -B -DskipTests --settings settings.xml
+./mvnw source:jar deploy -B -DskipTests --settings settings.xml


### PR DESCRIPTION
## Summary

Fixes issue #N/A

This PR updates the Java compiler target from 7 to 8 and upgrades Kotlin from 1.0.7 to 1.4.0, along with related dependency updates. These changes resolve build failures caused by Java 7 no longer being supported and conflicts between Kotlin versions.

Key changes:
- Changed Java compiler source/target from 1.7 to 8
- Updated Kotlin from 1.0.7 to 1.4.0
- Updated config4k and mockito-kotlin to compatible versions
- Fixed repository URL to use Maven Central instead of JCenter
- Modified deploy script to skip javadoc generation

